### PR TITLE
APNS Best Practices

### DIFF
--- a/public/v1/apns.php
+++ b/public/v1/apns.php
@@ -109,7 +109,8 @@
             CURLOPT_URL => APNS_URI. '/3/device/' . $deviceToken,
             CURLOPT_PORT => 443,
             CURLOPT_HTTPHEADER => [
-                'apns-push-type: ' . 'background',
+                'apns-push-type: ' . 'alert',
+                'apns-priority: ' . 10,
                 'apns-topic: ' . APNS_BUNDLEID,
                 'Authorization: Bearer ' . $jwt,
                 'User-Agent: Raivo OTP for MacOS APNS server'

--- a/public/v1/apns.php
+++ b/public/v1/apns.php
@@ -32,7 +32,7 @@
     define('APNS_KEYID', $ini['authentication']['key_id']);
     define('APNS_AUTHKEY', openssl_pkey_get_private(base64_decode($ini['authentication']['key'])));
     define('APNS_BUNDLEID', 'me.tij.Raivo-MacOS');
-    define('APNS_URI', APNS_PRODUCTION ? 'https://api.push.apple.com' : 'https://api.development.push.apple.com');
+    define('APNS_URI', APNS_PRODUCTION ? 'https://api.push.apple.com' : 'https://api.sandbox.push.apple.com');
 
     // Show PHP errors in development runs
     if (APNS_DEVELOPMENT) {


### PR DESCRIPTION
Created to address some concerns brought up here: https://github.com/raivo-otp/macos-receiver/issues/15
- [x] Upgrade `apns-push-type` from `background` to `alert` type. ([Background Notification Best Practices](https://developer.apple.com/documentation/usernotifications/setting_up_a_remote_notification_server/pushing_background_updates_to_your_app))
- [x] Set `apns-priority` to 10 (highest) per change in push-type above. 
- [x] Update APNS sandbox URI ([Establish a Connection to APNs](https://developer.apple.com/documentation/usernotifications/setting_up_a_remote_notification_server/sending_notification_requests_to_apns))